### PR TITLE
fix: return 'null' instead of -1 in readInteger2 function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ class PGDateParser {
       return (chr1 - CHAR_CODE_0) * 10 + (chr2 - CHAR_CODE_0);
     }
 
-    return -1;
+    return null;
   }
 
   private skipChar(char: number) {


### PR DESCRIPTION
failed parsing should return `null` not `-1`. It was a leftover from an experiment