### PR TITLE
fix: minimize npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "repository": "git@github.com:6fold/fast-postgres-date-parser.git",
   "author": "Jaan Oras <jaan.oras@gmail.com>",
   "license": "MIT",
+  "files": [
+    "dist",
+    "!dist/**/__tests__"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "tslint --project .",


### PR DESCRIPTION
Current unpacked size of this package is ~9.1MB, way too big. This is because the package contians unnecessary files.